### PR TITLE
Add hubot-scripts snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,29 @@ run `apm install docs-snippets`
 #
 # Returns the duplicated String.
 ```
+
+- [Hubot Scripts](https://github.com/github/hubot-scripts/)
+
+`hubot` completes in `.coffee` and `.js` to
+
+```coffee
+# Description:
+#   A description of your Hubot Script
+#
+# Commands:
+#   hubot Your command trigger - Description of what your command does
+#
+# Author:
+#   Your GitHub username
+```
+
+```javascript
+// Description:
+//   A description of your Hubot Script
+//
+// Commands:
+//   hubot Your command trigger - Description of what your command does
+//
+// Author:
+//   Your GitHub username
+```

--- a/snippets/hubot.cson
+++ b/snippets/hubot.cson
@@ -1,0 +1,27 @@
+".source.coffee" :
+  "Hubot Script skeleton" :
+    "prefix" : "hubot"
+    "body" : """
+      # Description:
+      #   ${1:A description of your Hubot Script}
+      #
+      # Commands:
+      #   hubot ${2:Your command trigger} - ${3:Description of what your command does}
+      #
+      # Author:
+      #   ${4:Your GitHub username}
+    """
+
+".source.js" :
+  "Hubot Script skeleton" :
+    "prefix" : "hubot"
+    "body" : """
+      // Description:
+      //   ${1:A description of your Hubot Script}
+      //
+      // Commands:
+      //   hubot ${2:Your command trigger} - ${3:Description of what your command does}
+      //
+      // Author:
+      //   ${4:Your GitHub username}
+      """


### PR DESCRIPTION
Adds snippets for the "documentation" comments at the top of hubot scripts, supports both `.coffee` and `.js` scripts.
