### PR TITLE
Added is phpdoc

### DIFF
--- a/snippets/phpdoc.cson
+++ b/snippets/phpdoc.cson
@@ -1,0 +1,19 @@
+# phpDoc snippet
+#
+# Examples
+#
+#  `phpdoc<tab>`
+#
+'.source.php':
+  'phpdoc':
+    'prefix': 'phpdoc'
+    'body': """
+      /**
+       * ${1:Description of what this does.}
+       *
+       * @param     $2
+       * @return    void
+       * @author    $3
+       * @copyright $4
+       */
+    """


### PR DESCRIPTION
This is simple snippet for function declarations, which I use in my code. Two notes: 
1. I'd like to predefine "author" and "copyright" as soon as Atom allows this.
2. It'd be nice (again, if Atom allows) to scan function parameters and add as many @param + type lines as needed.

As reference, Sublime Text has an excellent package for this purpose: https://github.com/spadgos/sublime-jsdocs
